### PR TITLE
wip: per environment acme issuer

### DIFF
--- a/acme/templates/cert-manager-prod-certificate.yaml
+++ b/acme/templates/cert-manager-prod-certificate.yaml
@@ -1,17 +1,18 @@
-{{- if .Values.jxRequirements.ingress.domain }}
-{{- if .Values.jxRequirements.ingress.tls.production }}
+{{- $environments := .Values.jxRequirements.environments }}
 apiVersion: cert-manager.io/v1alpha2
 kind: Certificate
 metadata:
-  name: "tls-{{ .Values.jxRequirements.ingress.domain | replace "." "-" }}-p"
+  {{- range $environments }}
+  {{- if and .ingress.tls.enabled .ingress.domain .ingress.tls.production }}
+  name: "tls-{{ .ingress.domain | replace "." "-" }}-p"
   labels:
     jenkins.io/letsencrypt-service: production
 spec:
-  secretName: "tls-{{ .Values.jxRequirements.ingress.domain | replace "." "-" }}-p"
+  secretName: "tls-{{ .ingress.domain | replace "." "-" }}-p"
   issuerRef:
     name: letsencrypt-prod
-  commonName: "*.{{ .Values.jxRequirements.ingress.domain }}"
+  commonName: "*.{{ .ingress.domain }}"
   dnsNames:
-  - "*.{{ .Values.jxRequirements.ingress.domain }}"
-{{- end }}
-{{- end }}
+  - "*.{{ .ingress.domain }}"
+  {{- end }}
+  {{- end }}

--- a/acme/templates/cert-manager-prod-issuer.yaml
+++ b/acme/templates/cert-manager-prod-issuer.yaml
@@ -1,4 +1,6 @@
-{{- if and .Values.jxRequirements.ingress.domain .Values.jxRequirements.ingress.tls.production }}
+{{- $provider := .Values.jxRequirements.cluster.provider }}
+{{- $projectID := .Values.jxRequirements.cluster.projectID }}
+{{- $environments := .Values.jxRequirements.environments }}
 apiVersion: cert-manager.io/v1alpha2
 kind: Issuer
 metadata:
@@ -6,28 +8,30 @@ metadata:
 spec:
   acme:
     server: https://acme-v02.api.letsencrypt.org/directory
-    email: "{{ .Values.jxRequirements.ingress.tls.email }}"
+    {{- range $environments }}
+    {{- if and .ingress.tls.enabled .ingress.tls.production .ingress.domain }}
+    email: "{{ .ingress.tls.email }}"
     # Name of a secret used to store the ACME account private key
     privateKeySecretRef:
       name: letsencrypt-prod
     solvers:
     - selector:
         dnsNames:
-        - "*.{{ .Values.jxRequirements.ingress.domain }}"
-        - "{{ .Values.jxRequirements.ingress.domain }}"
+        - "*.{{ .ingress.domain }}"
+        - "{{ .ingress.domain }}"
       # ACME DNS-01 provider configurations
       dns01:
-{{- if eq .Values.jxRequirements.cluster.provider "gke" }}
+        {{- if eq $provider "gke" }}
         clouddns:
           # The project in which to update the DNS zone
-          project: "{{ .Values.jxRequirements.cluster.projectID }}"
+          project: "{{ $projectID }}"
           # A secretKeyRef to a google cloud json service account
           serviceAccountSecretRef:
             name: external-dns-gcp-sa
             key: credentials.json
-{{- end }}
-{{- if eq .Values.jxRequirements.cluster.provider "eks" }}
+        {{- else if eq $provider "eks" }}
         route53:
           region: {{ .Values.jxRequirements.cluster.region }}
-{{- end }}
-{{- end }}
+        {{- end }}
+    {{- end }}
+    {{- end }}

--- a/acme/templates/cert-manager-selfsigned-issuer.yaml
+++ b/acme/templates/cert-manager-selfsigned-issuer.yaml
@@ -1,0 +1,11 @@
+{{- $environments := .Values.jxRequirements.environments }}
+{{- range $environments }}
+{{- if and .ingress.tls.enabled (not .ingress.domain) (not .ingress.tls.production) }}
+apiVersion: cert-manager.io/v1alpha2
+kind: Issuer
+metadata:
+  name: selfsigned
+spec:
+  selfSigned: {}
+{{- end }}
+{{- end }}

--- a/acme/templates/cert-manager-staging-certificate.yaml
+++ b/acme/templates/cert-manager-staging-certificate.yaml
@@ -1,17 +1,18 @@
-{{- if .Values.jxRequirements.ingress.tls.enabled }}
-{{- if not .Values.jxRequirements.ingress.tls.production }}
+{{- $environments := .Values.jxRequirements.environemnts }}
 apiVersion: cert-manager.io/v1alpha2
 kind: Certificate
 metadata:
-  name: "tls-{{ .Values.jxRequirements.ingress.domain | replace "." "-" }}-s"
+  {{- range $environments }}
+  {{- if and .ingress.tls.enabled .ingress.domain (not .ingress.tls.production) }}
+  name: "tls-{{ .ingress.domain | replace "." "-" }}-s"
   labels:
     jenkins.io/letsencrypt-service: staging
 spec:
-  secretName: "tls-{{ .Values.jxRequirements.ingress.domain | replace "." "-" }}-s"
+  secretName: "tls-{{ .ingress.domain | replace "." "-" }}-s"
   issuerRef:
     name: letsencrypt-staging
-  commonName: "*.{{ .Values.jxRequirements.ingress.domain }}"
+  commonName: "*.{{ .ingress.domain }}"
   dnsNames:
-  - "*.{{ .Values.jxRequirements.ingress.domain }}"
-{{- end }}
-{{- end }}
+  - "*.{{ .ingress.domain }}"
+  {{- end }}
+  {{- end }}

--- a/acme/templates/cert-manager-staging-issuer.yaml
+++ b/acme/templates/cert-manager-staging-issuer.yaml
@@ -1,5 +1,6 @@
-{{- if .Values.jxRequirements.ingress.tls.enabled }}
-{{- if not .Values.jxRequirements.ingress.tls.production }}
+{{- $provider := .Values.jxRequirements.cluster.provider }}
+{{- $projectID := .Values.jxRequirements.cluster.projectID }}
+{{- $environments := .Values.jxRequirements.environments }}
 apiVersion: cert-manager.io/v1alpha2
 kind: Issuer
 metadata:
@@ -7,29 +8,30 @@ metadata:
 spec:
   acme:
     server: https://acme-staging-v02.api.letsencrypt.org/directory
-    email: "{{ .Values.jxRequirements.ingress.tls.email }}"
+    {{- range $environments }}
+    {{- if and .ingress.tls.enabled (not .ingress.tls.production) .ingress.domain }}
+    email: "{{ .ingress.tls.email }}"
     # Name of a secret used to store the ACME account private key
     privateKeySecretRef:
-      name: letsencrypt-staging
+      name: letsencrypt-prod
     solvers:
     - selector:
         dnsNames:
-        - "*.{{ .Values.jxRequirements.ingress.domain }}"
-        - "{{ .Values.jxRequirements.ingress.domain }}"
+        - "*.{{ .ingress.domain }}"
+        - "{{ .ingress.domain }}"
       # ACME DNS-01 provider configurations
       dns01:
-{{- if eq .Values.jxRequirements.cluster.provider "gke" }}
+        {{- if eq $provider "gke" }}
         clouddns:
           # The project in which to update the DNS zone
-          project: "{{ .Values.jxRequirements.cluster.projectID }}"
+          project: "{{ $projectID }}"
           # A secretKeyRef to a google cloud json service account
           serviceAccountSecretRef:
             name: external-dns-gcp-sa
             key: credentials.json
-{{- end }}
-{{- if eq .Values.jxRequirements.cluster.provider "eks" }}
+        {{- else if eq $provider "eks" }}
         route53:
           region: {{ .Values.jxRequirements.cluster.region }}
-{{- end }}
-{{- end }}
-{{- end }}
+        {{- end }}
+    {{- end }}
+    {{- end }}

--- a/acme/values.yaml
+++ b/acme/values.yaml
@@ -3,12 +3,31 @@ jxRequirements:
     projectID: ""
     provider: ""
     region: ""
-  ingress:
-    domain: ""
-    externalDNS: false
-    namespaceSubDomain: -jx.
-    tls:
-      email: ""
-      enabled: true
-      production: true
-      secretName: ""
+  environments:
+  - ingress:
+      domain: ""
+      externalDNS: false
+      namespaceSubDomain: "-jx."
+      tls:
+        email: ""
+        enabled: true
+        production: false
+    key: dev
+  - ingress:
+      domain: ""
+      externalDNS: false
+      namespaceSubDomain: ""
+      tls:
+        email: ""
+        enabled: true
+        production: false
+    key: staging
+  - ingress:
+      domain: ""
+      externalDNS: false
+      namespaceSubDomain: ""
+      tls:
+        email: ""
+        enabled: true
+        production: true
+    key: production


### PR DESCRIPTION
WIP: this updates the current implementation which creates a single `Issuer` for the environment (`.Values.jxRequirements.ingress`) to configuring an `Issuer` per environment (`.Values.jxRequirements.environments`).

Self-signed: if and .ingress.tls.enabled (not .ingress.tls.production) (not .ingress.domain)
LE Staging: if and .ingress.tls.enabled (.not .ingress.tls.production) .ingress.domain
LE Production: if and .ingress.tls.enabled .ingress.tls.production .ingress.domain

**Note**: still have to add a `Certificate` for the self-signed issuer and test it all out.